### PR TITLE
Resolve missing `helper_base` in `iform_cron()`

### DIFF
--- a/iform.module
+++ b/iform.module
@@ -1496,8 +1496,7 @@ function iform_metatags_alter(&$metatags, $context) {
  */
 function iform_cron() {
   // Ensure helper_base is loaded.
-  $path = iform_client_helpers_path();
-  require_once $path . 'helper_base.php';
+  iform_load_helpers(['helper_base']);
   
   // Cache folder (note, not used if delegating to Drupal caching).
   $cacheFolder = helper_base::$cache_folder ? helper_base::$cache_folder : helper_base::relative_client_helper_path() . 'cache/';

--- a/iform.module
+++ b/iform.module
@@ -1495,6 +1495,10 @@ function iform_metatags_alter(&$metatags, $context) {
  * Cleans up old temporary files.
  */
 function iform_cron() {
+  // Ensure helper_base is loaded.
+  $path = iform_client_helpers_path();
+  require_once $path . 'helper_base.php';
+  
   // Cache folder (note, not used if delegating to Drupal caching).
   $cacheFolder = helper_base::$cache_folder ? helper_base::$cache_folder : helper_base::relative_client_helper_path() . 'cache/';
   if (file_exists($cacheFolder)) {


### PR DESCRIPTION
This fixes #14. Cron now runs correctly on my local sites.

I have no real experiece of developing with drupal, and the `require_once` call feels rather 'hacky'. Very open to rewriting these few lines if there's a better way of doing dependency injection here.